### PR TITLE
Fix bug in AlternatingRateStrategy

### DIFF
--- a/src/paystation/domain/AlternatingRateStrategy.java
+++ b/src/paystation/domain/AlternatingRateStrategy.java
@@ -14,9 +14,12 @@ public class AlternatingRateStrategy implements RateStrategy {
 
     @Override
     public int calculateTime(int payment) {
-        if (isWeekend())
-            return ProgressiveRateStrategy.calculateTime(payment);
-        return LinearRateStrategy.calculateTime(payment);
+        if (isWeekend()) {
+            ProgressiveRateStrategy progressiveRateStrategy = new ProgressiveRateStrategy();
+            return progressiveRateStrategy.calculateTime(payment);
+        }
+        LinearRateStrategy linearRateStrategy = new LinearRateStrategy();
+        return linearRateStrategy.calculateTime(payment);
     }
 
     /**


### PR DESCRIPTION
calculateTime() called non-static methods in LinearRateStrategy and ProgressiveRateStrategy without creating an object. This fixes that.